### PR TITLE
marine: prevent overflow in PAYLOAD_TYPE values

### DIFF
--- a/message_definitions/v1.0/marine.xml
+++ b/message_definitions/v1.0/marine.xml
@@ -100,19 +100,19 @@
       <entry value="6" name="PAYLOAD_TYPE_FLS">
         <description>Forward Look Sonar Payload.</description>
       </entry>
-      <entry value="1001" name="PAYLOAD_TYPE_GENERIC_1">
+      <entry value="101" name="PAYLOAD_TYPE_GENERIC_1">
         <description>Generic Payload 1.</description>
       </entry>
-      <entry value="1002" name="PAYLOAD_TYPE_GENERIC_2">
+      <entry value="102" name="PAYLOAD_TYPE_GENERIC_2">
         <description>Generic Payload 2.</description>
       </entry>
-      <entry value="1003" name="PAYLOAD_TYPE_GENERIC_3">
+      <entry value="103" name="PAYLOAD_TYPE_GENERIC_3">
         <description>Generic Payload 3.</description>
       </entry>
-      <entry value="1004" name="PAYLOAD_TYPE_GENERIC_4">
+      <entry value="104" name="PAYLOAD_TYPE_GENERIC_4">
         <description>Generic Payload 4.</description>
       </entry>
-      <entry value="1005" name="PAYLOAD_TYPE_GENERIC_5">
+      <entry value="105" name="PAYLOAD_TYPE_GENERIC_5">
         <description>Generic Payload 5.</description>
       </entry>
     </enum>


### PR DESCRIPTION
The payload_type fields are only uint8_t, so we have to use values smaller equal 255.