### PR TITLE
marine: use MAV_CMD_REQUEST_MESSAGE instead

### DIFF
--- a/message_definitions/v1.0/marine.xml
+++ b/message_definitions/v1.0/marine.xml
@@ -296,13 +296,14 @@
       <field type="uint8_t" name="result" enum="PAYLOAD_LIST_RESULT">Payload List result.</field>
     </message>
     <message id="44205" name="PAYLOAD_STATUS_REQUEST">
-      <description>Request the status of the payload item with the specified payload ID. The response of the system to this message should be a PAYLOAD_STATUS message.</description>
+      <deprecated since="2022-05" replaced_by="MAV_CMD_REQUEST_MESSAGE"/>
+      <description>Request the status of the payload item with the specified payload ID. The response of the system to this message should be a PAYLOAD_STATUS message. Note: this message has been deprecated in favor of using MAV_CMD_REQUEST_MESSAGE with param1 specifiying the message ID and param2 specifying the payload ID.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint8_t" name="payload_id">Payload ID.</field>
     </message>
     <message id="44206" name="PAYLOAD_STATUS">
-      <description>This message is emitted as response to PAYLOAD_STATUS_REQUEST, and contains the details (ID and Type) and health and status (as bitmasks) of the specified payload.</description>
+      <description>This message is emitted as response to MAV_CMD_REQUEST_MESSAGE with param1 specifying the message ID (44206) andparam2 specifying the payload ID, and contains the details (ID and Type) and health and status (as bitmasks) of the specified payload.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint8_t" name="payload_id">Payload ID, 1 - N.</field>


### PR DESCRIPTION
By using the command MAV_CMD_REQUEST_MESSAGE we have the advantage that we can re-use the existing infrastructure for commands which includes:
- Retransmission in case of lost messages (instead of just a timeout).
- Better acks to signal if something is unsupported or deny it if the payload ID is invalid (again, instead of just a timeout).