### PR TITLE
marine: make PAYLOAD_CHANGE more resilient

### DIFF
--- a/message_definitions/v1.0/marine.xml
+++ b/message_definitions/v1.0/marine.xml
@@ -311,11 +311,13 @@
       <field type="uint16_t" name="payload_state" enum="PAYLOAD_STATE" display="bitmask" print_format="0x%04x">Bitmap showing the states of payload. Value of 0: state is false. Value of 1: state is true.</field>
     </message>
     <message id="44207" name="PAYLOAD_CHANGE">
-      <description>Broadcast on change of Payload List, specifies the change (added/removed) and ID of the payload.</description>
+      <description>Broadcast on change of Payload List, specifies the change (added/removed) and ID of the payload. This message should be sent out on every change as well as regularly (e.g. every 10s or 60s).</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint8_t" name="payload_change">Payload ID change, value 1 : ID Added, value 0 : ID Removed</field>
-      <field type="uint8_t" name="payload_id">ID of new payload added.</field>
+      <field type="uint8_t" name="payload_change">Payload ID change, value 1 : ID Added, value 0 : ID Removed, value 255: no change</field>
+      <field type="uint8_t" name="payload_id">ID of new payload added or removed.</field>
+      <extensions/>
+      <field type="uint8_t" name="change_counter">Counter incremented on each change.</field>
     </message>
     <message id="44300" name="WATER_CURRENT">
       <description>Water current values. Note: Calculated Water current = (Vehicle Velocity - Measured Current).</description>


### PR DESCRIPTION
If a receiver of the PAYLOAD_CHANGE message misses one message, its state would no longer be correct. The only way to recover from that would be to re-download all payloads from scratch every now and then.

In order to avoid having to update all payloads every now and then, I suggest to send out the PAYLOAD_CHANGE message regularly (albeit not too often) including a change_counter to make the receiver aware if anything has changed, at least eventually.

If the receiver misses two actual changes in succession, it still has to re-download all of them from scratch, however, that's probably unlikely.