### PR TITLE
marine: use meters instead of centimeters as float

### DIFF
--- a/message_definitions/v1.0/marine.xml
+++ b/message_definitions/v1.0/marine.xml
@@ -325,7 +325,7 @@
       <field type="float" name="calculated_current_x" units="m/s">Calculated Water current in X (NED)</field>
       <field type="float" name="calculated_current_y" units="m/s">Calculated Water current in Y (NED)</field>
       <field type="float" name="calculated_current_z" units="m/s">Calculated Water current in Z (NED)</field>
-      <field type="float" name="distance" units="cm">Measurement distance from the sensor</field>
+      <field type="float" name="distance" units="m">Measurement distance from the sensor</field>
     </message>
     <message id="44301" name="DVL">
       <description>Doppler Velocity Log Sensor. Used to provide vehicle velocity.</description>


### PR DESCRIPTION
I don't think there is a good reason to use cm when it's a float.
I'd just use the SI unit instead.