### PR TITLE
marine: add AUTONOMY_STATE_RECOVERING

### DIFF
--- a/message_definitions/v1.0/marine.xml
+++ b/message_definitions/v1.0/marine.xml
@@ -76,6 +76,9 @@
       <entry value="6" name="AUTONOMY_STATE_STOPPED">
         <description>Autonomy System execution stopped early.</description>
       </entry>
+      <entry value="7" name="AUTONOMY_STATE_RECOVERING">
+        <description>Autonomy System heading to recovery position.</description>
+      </entry>
     </enum>
     <enum name="PAYLOAD_TYPE">
       <description>Supported Payload types.</description>


### PR DESCRIPTION
This state is required in response to the demand GO_TO_RECOVERY.