### PR TITLE
Add AUTONOMY_COMPONENT_MISSION

### DIFF
--- a/message_definitions/v1.0/marine.xml
+++ b/message_definitions/v1.0/marine.xml
@@ -52,6 +52,9 @@
       <entry value="64" name="AUTONOMY_COMPONENT_ACOMMS">
         <description>0x40 Acomms Modem</description>
       </entry>
+      <entry value="128" name="AUTONOMY_COMPONENT_MISSION">
+        <description>0x80 Autonomy Mission</description>
+      </entry>
     </enum>
     <enum name="AUTONOMY_STATE">
       <description>Current state of the Autonomy System.</description>


### PR DESCRIPTION
This is used to allow the autonomy to report the status of the meta-autonomy mission (NOT THE MAVLINK MISSION!)