### PR TITLE
Expose some snippet metadata in the snippet header

### DIFF
--- a/message_definitions/v1.0/marine.xml
+++ b/message_definitions/v1.0/marine.xml
@@ -260,6 +260,7 @@
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint32_t" name="destination_address">Acomms message destination, 0 for broadcast.</field>
       <field type="uint8_t" name="snippet_confidence" units="%" >Contact snippet confidence (0 to 100).</field>
+      <field type="uint16_t" name="snippet_id">Contact snippet identifier. Unique for each snippet.</field>
       <field type="uint8_t" name="message_length">Length of the data transported in message.</field>
       <field type="uint8_t[128]" name="message">Variable length message. The message length is defined by message_length.</field>
     </message>


### PR DESCRIPTION
We keep the black box of the snippet message but we to expose the snippet id so we can match snippet messages to snippet files